### PR TITLE
Fix: 북마크 추가 다이얼로그의 폴더 목록 동기화 문제 해결

### DIFF
--- a/src/components/AddBookmarkDialog.tsx
+++ b/src/components/AddBookmarkDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -14,7 +14,6 @@ import {
 import { createBookmark } from "@/lib/bookmarks";
 import { TagInput } from "@/components/TagInput";
 import { addTagToBookmark } from "@/lib/tags";
-import { getFolders } from "@/lib/folders";
 import { Database } from "@/lib/supabase";
 
 type Tag = Database["public"]["Tables"]["tags"]["Row"];
@@ -23,11 +22,13 @@ type Folder = Database["public"]["Tables"]["folders"]["Row"];
 interface AddBookmarkDialogProps {
   onBookmarkAdded: () => void;
   selectedFolderId?: string;
+  folders: Folder[];
 }
 
 export const AddBookmarkDialog = ({
   onBookmarkAdded,
   selectedFolderId,
+  folders
 }: AddBookmarkDialogProps) => {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -38,20 +39,6 @@ export const AddBookmarkDialog = ({
     folder_id: selectedFolderId || "",
   });
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
-  const [folders, setFolders] = useState<Folder[]>([]);
-
-  // 폴더 목록 로드
-  useEffect(() => {
-    const loadFolders = async () => {
-      try {
-        const foldersData = await getFolders();
-        setFolders(foldersData);
-      } catch (error) {
-        console.error("폴더 로딩 실패:", error);
-      }
-    };
-    loadFolders();
-  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/BookmarkApp.tsx
+++ b/src/components/BookmarkApp.tsx
@@ -178,6 +178,7 @@ export const BookmarkApp = () => {
           <AddBookmarkDialog
             onBookmarkAdded={loadData}
             selectedFolderId={selectedFolderId}
+            folders={folders}
           />
         </div>
 


### PR DESCRIPTION
## 📋 문제 설명 (Problem)

폴더 생성 후 북마크 추가 다이얼로그에서 새로 생성된 폴더가 즉시 표시되지 않는 문제가 있었습니다.

**재현 단계:**
1. 새 폴더 생성
2. 북마크 추가 다이얼로그 열기
3. 폴더 선택 드롭다운 확인
4. 새로 생성된 폴더가 목록에 없음 (새로고침 시에만 표시)

**원인:**
- `BookmarkApp` 컴포넌트와 `AddBookmarkDialog` 컴포넌트가 각각 독립적으로 폴더 목록을 관리
- `AddBookmarkDialog`가 `useEffect(() => { loadFolders() }, [])`를 통해 초기 렌더링 시에만 폴더 데이터를 가져옴
- `AddBookmarkDialog`는 `BookmarkApp` 렌더링 시점에 마운트되어 계속 유지되므로, 폴더 생성 후에도 초기 데이터를 계속 사용
- 폴더 생성 후 상위 컴포넌트의 상태는 업데이트되지만, `AddBookmarkDialog`의 로컬 상태는 업데이트되지 않음

## 🛠️ 해결 방법 (Solution)

- `AddBookmarkDialog`에서 자체적인 폴더 데이터 fetching 제거
- 상위 컴포넌트(`BookmarkApp`)에서 폴더 목록을 props로 전달
- 데이터 중복 및 동기화 문제 해결

## 🔧 변경 사항 (Changes)

### 📝 AddBookmarkDialog.tsx
- `folders` prop 추가
- 자체 폴더 데이터 fetching `useEffect` 제거
- Props 인터페이스 업데이트

### 📝 BookmarkApp.tsx  
- `AddBookmarkDialog`에 `folders` prop 전달